### PR TITLE
feat: execute agentic workflow graphs

### DIFF
--- a/apps/x-reason-web/src/app/api/reasoning/fixtures/agenticWorkflow.ts
+++ b/apps/x-reason-web/src/app/api/reasoning/fixtures/agenticWorkflow.ts
@@ -1,0 +1,102 @@
+import { StateConfig } from "@/app/api/reasoning";
+
+export const AGENTIC_WORKFLOW_SAMPLE_QUERY =
+  "Plan a launch workflow where research and compliance run in parallel, a reviewer can send the plan back for revision, and human approval is required before execution.";
+
+export function getAgenticWorkflowSampleStateResult(stateLabel: string): string | undefined {
+  const results: Record<string, string> = {
+    DraftPlan:
+      "Drafted a launch plan with explicit research, compliance, critique, revision, approval, and execution checkpoints.",
+    ResearchMarket:
+      "Market research identified target segments, competitive pressure, launch timing, and customer evidence needed before execution.",
+    ReviewCompliance:
+      "Compliance review identified policy, safety, claims, data handling, and regulatory constraints for the launch.",
+    CritiquePlan:
+      "The reviewer found one revision needed on the first pass; the revised plan is ready for human approval on the second pass.",
+    RevisePlan:
+      "Updated the launch plan using reviewer feedback and prepared it for a second critique pass.",
+    ExecutePlan:
+      "Executed the approved launch plan with the research and compliance constraints incorporated.",
+  };
+
+  return results[stateLabel];
+}
+
+export function createAgenticWorkflowTortureFixture(): StateConfig[] {
+  return [
+    {
+      id: "DraftPlan",
+      task: "Draft the initial launch plan from the user request.",
+      transitions: [
+        { on: "CONTINUE", target: "ParallelDiscovery" },
+        { on: "ERROR", target: "failure" },
+      ],
+    },
+    {
+      id: "ParallelDiscovery",
+      type: "parallel",
+      states: [
+        {
+          id: "ResearchMarket",
+          task: "Research customer, market, and competitive constraints.",
+          transitions: [
+            { on: "CONTINUE", target: "success" },
+            { on: "ERROR", target: "failure" },
+          ],
+        },
+        {
+          id: "ReviewCompliance",
+          task: "Review policy, safety, and regulatory constraints.",
+          transitions: [
+            { on: "CONTINUE", target: "success" },
+            { on: "ERROR", target: "failure" },
+          ],
+        },
+      ],
+      onDone: "CritiquePlan",
+    },
+    {
+      id: "CritiquePlan",
+      task: "Critique the plan and decide whether it needs revision or can move to approval.",
+      includesLogic: true,
+      transitions: [
+        { on: "CONTINUE", target: "RevisePlan" },
+        { on: "CONTINUE", target: "HumanApproval" },
+        { on: "ERROR", target: "failure" },
+      ],
+    },
+    {
+      id: "RevisePlan",
+      task: "Revise the plan using critique feedback.",
+      transitions: [
+        { on: "CONTINUE", target: "CritiquePlan" },
+        { on: "ERROR", target: "failure" },
+      ],
+    },
+    {
+      id: "HumanApproval",
+      task: "Pause for human approval before execution.",
+      transitions: [
+        { on: "CONTINUE", target: "ExecutePlan" },
+        { on: "CONTINUE", target: "RevisePlan" },
+        { on: "ERROR", target: "failure" },
+      ],
+    },
+    {
+      id: "ExecutePlan",
+      task: "Execute the approved plan.",
+      transitions: [
+        { on: "CONTINUE", target: "success" },
+        { on: "ERROR", target: "failure" },
+      ],
+    },
+    {
+      id: "success",
+      type: "final",
+    },
+    {
+      id: "failure",
+      type: "final",
+    },
+  ];
+}

--- a/apps/x-reason-web/src/app/components/StateMachineVisualizer.tsx
+++ b/apps/x-reason-web/src/app/components/StateMachineVisualizer.tsx
@@ -36,6 +36,45 @@ interface StateMachineConfig {
   states?: Record<string, unknown>;
 }
 
+type TransitionTarget = string | { target?: string } | Array<{ target?: string } | string>;
+
+type MermaidStateConfig = {
+  on?: Record<string, TransitionTarget>;
+  onDone?: TransitionTarget;
+  states?: Record<string, unknown>;
+};
+
+const INTERNAL_STATE_NAMES = new Set(['pending', 'success', 'failure', 'pause']);
+
+function getStateNodeId(name: string) {
+  return `state_${name.replace(/[^a-zA-Z0-9_]/g, '_')}`;
+}
+
+function getStateLabel(name: string) {
+  return name.replace(/\|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, '');
+}
+
+function getTransitionTargets(target: TransitionTarget): string[] {
+  if (typeof target === 'string') {
+    return [target];
+  }
+
+  if (Array.isArray(target)) {
+    return target.flatMap(getTransitionTargets);
+  }
+
+  if (target?.target) {
+    return [target.target];
+  }
+
+  return [];
+}
+
+function shouldRenderChildren(stateConfig?: MermaidStateConfig) {
+  const childNames = Object.keys(stateConfig?.states || {});
+  return childNames.some((name) => !INTERNAL_STATE_NAMES.has(name));
+}
+
 interface StateMachineVisualizerProps {
   machine: StateMachineConfig | null;
   interpreter?: StateMachineInterpreter | null;
@@ -109,23 +148,67 @@ export function StateMachineVisualizer({
     if (!machine) return '';
 
     const states = machine.config?.states || machine.states || {};
-    const stateNames = Object.keys(states).filter(name => !['success', 'failure'].includes(name));
+    const stateNames = Object.keys(states);
+    const nonFinalStateNames = stateNames.filter(name => !['success', 'failure'].includes(name));
 
     let mermaid = 'stateDiagram-v2\n';
-    mermaid += '    [*] --> ' + (stateNames[0] || 'success') + '\n\n';
+    mermaid += '    [*] --> ' + getStateNodeId(nonFinalStateNames[0] || 'success') + '\n\n';
+
+    const appendStateDeclaration = (
+      stateName: string,
+      stateConfig: MermaidStateConfig | undefined,
+      indent = '    ',
+    ) => {
+      if (!shouldRenderChildren(stateConfig)) {
+        mermaid += `${indent}state "${getStateLabel(stateName)}" as ${getStateNodeId(stateName)}\n`;
+        return;
+      }
+
+      mermaid += `${indent}state "${getStateLabel(stateName)}" as ${getStateNodeId(stateName)} {\n`;
+      Object.entries(stateConfig?.states || {})
+        .filter(([childName]) => !INTERNAL_STATE_NAMES.has(childName))
+        .forEach(([childName, childConfig]) => {
+          appendStateDeclaration(childName, childConfig as MermaidStateConfig, `${indent}    `);
+        });
+      mermaid += `${indent}}\n`;
+    };
+
+    stateNames.forEach((stateName) => {
+      appendStateDeclaration(stateName, states[stateName] as MermaidStateConfig | undefined);
+    });
+    mermaid += '\n';
 
     // Add transitions based on actual state config
-    stateNames.forEach((stateName) => {
-      const stateConfig = states[stateName];
+    const appendTransitions = (stateName: string, stateConfig: MermaidStateConfig | undefined) => {
       const transitions = stateConfig?.on || {};
 
       Object.entries(transitions).forEach(([event, target]) => {
-        mermaid += `    ${stateName} --> ${target}: ${event}\n`;
+        getTransitionTargets(target).forEach((targetState) => {
+          mermaid += `    ${getStateNodeId(stateName)} --> ${getStateNodeId(targetState)}: ${event}\n`;
+        });
       });
+
+      if (stateConfig?.onDone) {
+        getTransitionTargets(stateConfig.onDone).forEach((targetState) => {
+          mermaid += `    ${getStateNodeId(stateName)} --> ${getStateNodeId(targetState)}: done\n`;
+        });
+      }
+
+      if (!shouldRenderChildren(stateConfig)) return;
+
+      Object.entries(stateConfig?.states || {})
+        .filter(([childName]) => !INTERNAL_STATE_NAMES.has(childName))
+        .forEach(([childName, childConfig]) => {
+          appendTransitions(childName, childConfig as MermaidStateConfig);
+        });
+    };
+
+    stateNames.forEach((stateName) => {
+      appendTransitions(stateName, states[stateName] as MermaidStateConfig | undefined);
     });
 
-    mermaid += '\n    success --> [*]\n';
-    mermaid += '    failure --> [*]\n';
+    mermaid += '\n    ' + getStateNodeId('success') + ' --> [*]\n';
+    mermaid += '    ' + getStateNodeId('failure') + ' --> [*]\n';
 
     return mermaid;
   }, [machine]);

--- a/apps/x-reason-web/src/app/components/chemli/ReasonDemo.tsx
+++ b/apps/x-reason-web/src/app/components/chemli/ReasonDemo.tsx
@@ -11,6 +11,10 @@ import {
     AgentSubmissionLogic 
 } from "@/app/templates";
 import { parseStateMachineJson } from "@/app/utils";
+import {
+    AGENTIC_WORKFLOW_SAMPLE_QUERY,
+    createAgenticWorkflowTortureFixture,
+} from "@/app/api/reasoning/fixtures/agenticWorkflow";
 
 // Chemli-specific submission logic
 const chemliSubmissionLogic: AgentSubmissionLogic = async ({
@@ -23,6 +27,24 @@ const chemliSubmissionLogic: AgentSubmissionLogic = async ({
     setComponentToRender,
     aiConfig
 }) => {
+    if (userQuery.trim() === AGENTIC_WORKFLOW_SAMPLE_QUERY) {
+        dispatch({
+            type: "SET_STATE",
+            value: {
+                states: createAgenticWorkflowTortureFixture(),
+                solution:
+                    "Agentic workflow fixture: parallel discovery, critique/revision loop, human approval, and final execution.",
+                query: userQuery,
+                currentState: undefined,
+                context: undefined,
+                event: undefined,
+            }
+        });
+
+        setComponentToRender(<Success message="Agentic workflow loaded. Review the generated state machine below." />);
+        return;
+    }
+
     // Check if required dependencies are available
     if (!solver) {
         setComponentToRender(<Error message="Solver not initialized. Please refresh the page." />);
@@ -120,6 +142,7 @@ const chemliSubmissionLogic: AgentSubmissionLogic = async ({
 
 // Sample chemical development queries to help users understand what Chemli can do
 const sampleQueries = [
+    AGENTIC_WORKFLOW_SAMPLE_QUERY,
     "Create a moisturizing face cream formula with SPF protection",
     "I need a sulfate-free shampoo for dry hair with natural ingredients",
     "Develop a long-lasting lipstick formula with high pigmentation",
@@ -138,6 +161,9 @@ const chemliConfig: AgentConfig = {
     submitButtonText: "Generate Product Formula",
     processingButtonText: "Generating Formula...",
     sampleQueries,
+    sampleQueryBadges: {
+        [AGENTIC_WORKFLOW_SAMPLE_QUERY]: "Parallel",
+    },
     layout: 'grid',
     features: {
         expandableView: true,

--- a/apps/x-reason-web/src/app/templates/AgentDemoTemplate.tsx
+++ b/apps/x-reason-web/src/app/templates/AgentDemoTemplate.tsx
@@ -56,11 +56,12 @@ export const JsonHighlighter = ({ json, className = "" }: { json: string; classN
     );
 };
 
-export const SampleQueries = ({ samples, onSelect, disabled, isExpanded }: { 
+export const SampleQueries = ({ samples, onSelect, disabled, isExpanded, sampleBadges }: {
     samples: string[], 
     onSelect: (sample: string) => void,
     disabled?: boolean,
-    isExpanded?: boolean
+    isExpanded?: boolean,
+    sampleBadges?: Record<string, string>,
 }) => {
     // Start with a default length that works for SSR
     const defaultLength = isExpanded ? 120 : 50;
@@ -108,6 +109,7 @@ export const SampleQueries = ({ samples, onSelect, disabled, isExpanded }: {
                     {samples.map((sample, index) => {
                         const isLong = sample.length > truncationLength;
                         const displayText = isLong ? `${sample.substring(0, truncationLength)}...` : sample;
+                        const badge = sampleBadges?.[sample];
                         
                         const buttonElement = (
                             <Button
@@ -116,9 +118,20 @@ export const SampleQueries = ({ samples, onSelect, disabled, isExpanded }: {
                                 size="sm"
                                 onClick={() => onSelect(sample)}
                                 disabled={disabled}
-                                className="text-xs h-7 px-2 max-w-[calc(100%-0.25rem)] flex-shrink min-w-0 break-words"
+                                className={`text-xs min-h-7 h-auto px-2 py-1 max-w-[calc(100%-0.25rem)] flex-shrink min-w-0 break-words ${
+                                    badge
+                                        ? 'border-amber-300 bg-amber-50 text-amber-950 hover:bg-amber-100'
+                                        : ''
+                                }`}
                             >
-                                <span className="truncate block w-full text-left">{displayText}</span>
+                                <span className="flex min-w-0 items-center gap-1.5">
+                                    {badge && (
+                                        <span className="shrink-0 rounded border border-amber-300 bg-white px-1 py-0.5 text-[10px] font-semibold uppercase leading-none text-amber-800">
+                                            {badge}
+                                        </span>
+                                    )}
+                                    <span className="truncate block w-full text-left">{displayText}</span>
+                                </span>
                             </Button>
                         );
 
@@ -149,6 +162,7 @@ export interface AgentConfig {
     submitButtonText: string;
     processingButtonText: string;
     sampleQueries?: string[];
+    sampleQueryBadges?: Record<string, string>;
     layout: 'grid' | 'flex';
     features: {
         expandableView?: boolean;
@@ -222,6 +236,7 @@ export function AgentDemoTemplate({ config, hookReturn, inputRef, stateRef }: Ag
                         onSelect={fillSampleQuery}
                         disabled={isLoading}
                         isExpanded={isExpanded}
+                        sampleBadges={config.sampleQueryBadges}
                     />
                 )}
 

--- a/apps/x-reason-web/src/app/templates/MultiStepAgentDemoTemplate.tsx
+++ b/apps/x-reason-web/src/app/templates/MultiStepAgentDemoTemplate.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from "react";
-import { createMachine, createActor } from "xstate";
+import { createMachine } from "xstate";
 import { Button } from "@/app/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/app/components/ui/card";
 import { ProgressBar } from "@/app/components/ProgressBar";
@@ -12,8 +12,21 @@ import { AIProviderSelector } from "@/app/components/ui/ai-provider-selector";
 import { ArrowUp, ArrowLeft, ArrowRight, Play, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
 import Interpreter from "@/app/api/reasoning/Interpreter.v1.headed";
 import { LocalStorage } from "@/app/components";
-import { programV1 } from '@/app/api/reasoning';
-import { safeExtractContent } from '@/app/utils';
+import { programV1, StateConfig, Task } from '@/app/api/reasoning';
+import {
+  AGENTIC_WORKFLOW_SAMPLE_QUERY,
+  getAgenticWorkflowSampleStateResult,
+} from '@/app/api/reasoning/fixtures/agenticWorkflow';
+import {
+  ChooseTransition,
+  cloneStateConfigs,
+  collectExecutableStates,
+  matchTransitionTarget,
+  runStateMachineInterpreter,
+  safeExtractContent,
+  selectHumanApprovalTransition,
+  stateRequiresHumanApproval,
+} from '@/app/utils';
 import { initializeInspector } from '@/app/lib/inspector';
 
 const STEPS = [
@@ -21,6 +34,32 @@ const STEPS = [
   { id: 'compile', label: 'Compile' },
   { id: 'execute', label: 'Execute' }
 ];
+
+type SendableActor = {
+  send: (event: Record<string, unknown>) => void;
+};
+
+type PendingHumanApproval = {
+  stateLabel: string;
+  task?: string;
+  approve: () => void;
+  requestChanges: () => void;
+};
+
+function isSendableActor(actor: unknown): actor is SendableActor {
+  return (
+    typeof actor === "object" &&
+    actor !== null &&
+    "send" in actor &&
+    typeof (actor as { send?: unknown }).send === "function"
+  );
+}
+
+function sendActorEvent(actor: unknown, event: Record<string, unknown>) {
+  if (isSendableActor(actor)) {
+    actor.send(event);
+  }
+}
 
 export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: AgentDemoTemplateProps) {
   const [currentStep, setCurrentStep] = useState(0);
@@ -32,8 +71,8 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
   const [collapsedStates, setCollapsedStates] = useState<Set<string>>(new Set());
   const [savedInputValue, setSavedInputValue] = useState<string>('');
   const [hasExecutedBefore, setHasExecutedBefore] = useState(false);
-  const [currentActor, setCurrentActor] = useState<Record<string, unknown> | null>(null);
   const [copyConfigSuccess, setCopyConfigSuccess] = useState(false);
+  const [pendingHumanApproval, setPendingHumanApproval] = useState<PendingHumanApproval | null>(null);
   
   const {
     isLoading,
@@ -59,13 +98,16 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
     }
     
     if (states && hookReturn.context) {
+      const contextFunctions = (hookReturn.context as { functions?: Map<string, Task> }).functions;
       console.log('Compiling states:', states);
-      console.log('Available functions:', hookReturn.context.functions);
+      console.log('Available functions:', contextFunctions);
       
       try {
+        const sourceStateConfigs = cloneStateConfigs(states as StateConfig[]);
+        const machineStateConfigs = cloneStateConfigs(sourceStateConfigs);
         // Use the existing programV1 function to create the machine
         // This is what the reasoning engine actually uses
-        const machine = programV1(states, hookReturn.context.functions || new Map());
+        const machine = programV1(machineStateConfigs, contextFunctions || new Map());
         console.log('Created machine with programV1:', machine);
         
         setCompiledMachine({
@@ -73,8 +115,9 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
           config: machine.config,
           id: machine.id,
           states: machine.config.states,
-          stateConfigs: states,
-          functions: hookReturn.context.functions
+          stateConfigs: sourceStateConfigs,
+          compiledStateConfigs: machineStateConfigs,
+          functions: contextFunctions
         });
         
         setCurrentStep(1);
@@ -99,16 +142,12 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
             simulateStateExecution(state.id as string, savedInputValue || inputRef.current?.value || '')
               .then(() => {
                 // Send the CONTINUE event to transition to next state
-                if (context.actor) {
-                  console.log(`Sending CONTINUE event from ${state.id as string}`);
-                  (context.actor as Record<string, unknown>).send({ type: 'CONTINUE' });
-                }
+                console.log(`Sending CONTINUE event from ${state.id as string}`);
+                sendActorEvent(context.actor, { type: 'CONTINUE' });
               })
               .catch((error) => {
                 console.error(`Error in state ${state.id as string}, sending ERROR event:`, error);
-                if (context.actor) {
-                  (context.actor as Record<string, unknown>).send({ type: 'ERROR', error });
-                }
+                sendActorEvent(context.actor, { type: 'ERROR', error });
               });
           };
 
@@ -118,13 +157,39 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
           });
         });
         
-        const fallbackMachine = machineMacro(stepsMap);
+        const fallbackMachineConfig = {
+          id: `${config.name.toLowerCase()}-fallback-machine`,
+          initial: (states as Array<Record<string, unknown>>)[0]?.id as string | undefined,
+          states: Object.fromEntries(
+            (states as Array<Record<string, unknown>>).map((state, index, allStates) => [
+              state.id as string,
+              state.type === 'final'
+                ? { type: 'final' }
+                : {
+                    entry: ({ context, event, self }: Record<string, unknown>) => {
+                      const step = stepsMap.get(state.id as string);
+                      const implementation = step?.implementation as
+                        | ((ctx: Record<string, unknown>, evt: Record<string, unknown>) => void)
+                        | undefined;
+                      implementation?.({ ...(context as Record<string, unknown>), actor: self }, event as Record<string, unknown>);
+                    },
+                    on: {
+                      CONTINUE: (allStates[index + 1]?.id as string | undefined) || 'success',
+                      ERROR: 'failure',
+                    },
+              },
+            ]),
+          ),
+        };
+        const fallbackMachine = createMachine(
+          fallbackMachineConfig as Parameters<typeof createMachine>[0],
+        );
         setCompiledMachine({
           machine: fallbackMachine,
           config: fallbackMachine.config,
           id: fallbackMachine.id,
           states: fallbackMachine.config.states,
-          stateConfigs: states,
+          stateConfigs: cloneStateConfigs(states as StateConfig[]),
           functions: stepsMap
         });
         
@@ -155,16 +220,12 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
             simulateStateExecution(state.id as string, savedInputValue || inputRef.current?.value || '')
               .then(() => {
                 // Send the CONTINUE event to transition to next state
-                if (context.actor) {
-                  console.log(`Sending CONTINUE event from ${state.id as string}`);
-                  (context.actor as Record<string, unknown>).send({ type: 'CONTINUE' });
-                }
+                console.log(`Sending CONTINUE event from ${state.id as string}`);
+                sendActorEvent(context.actor, { type: 'CONTINUE' });
               })
               .catch((error) => {
                 console.error(`Error in state ${state.id as string}, sending ERROR event:`, error);
-                if (context.actor) {
-                  (context.actor as Record<string, unknown>).send({ type: 'ERROR', error });
-                }
+                sendActorEvent(context.actor, { type: 'ERROR', error });
               });
           };
 
@@ -232,7 +293,7 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
             config: machineConfig,
             id: machine.id,
             states: machineConfig.states,
-            stateConfigs: states,
+            stateConfigs: cloneStateConfigs(states as StateConfig[]),
             functions: functionsMap
           });
           
@@ -258,15 +319,120 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
   };
 
   const getExecutableStates = () => {
+    const sourceStates = (compiledMachine?.stateConfigs as StateConfig[] | undefined) || [];
     const seen = new Set<string>();
-    return ((compiledMachine?.stateConfigs as Array<Record<string, unknown>> | undefined) || [])
-      .filter((state: Record<string, unknown>) => state.type !== 'final')
-      .filter((state: Record<string, unknown>) => {
+    return collectExecutableStates(sourceStates)
+      .filter((state: StateConfig) => {
         const id = String(state.id || '');
         if (!id || seen.has(id)) return false;
         seen.add(id);
         return true;
+      }) as Array<Record<string, unknown>>;
+  };
+
+  const chooseTransitionWithAI: ChooseTransition = async ({
+    stateLabel,
+    query,
+    result,
+    context,
+    transitions,
+    trace,
+  }) => {
+    if (transitions.length <= 1) {
+      return transitions[0]?.target;
+    }
+
+    if (result.startsWith("HUMAN_DECISION:")) {
+      const decision = result.includes("changes_requested")
+        ? "changes_requested"
+        : "approved";
+      return selectHumanApprovalTransition(decision, transitions);
+    }
+
+    if (query === AGENTIC_WORKFLOW_SAMPLE_QUERY) {
+      if (stateLabel === "CritiquePlan") {
+        const critiqueCompletions = trace.filter(
+          (entry) => entry.state === "CritiquePlan" && entry.event === "complete",
+        ).length;
+        const targetLabel = critiqueCompletions <= 1 ? "RevisePlan" : "HumanApproval";
+        return transitions.find((transition) => transition.label === targetLabel)?.target;
+      }
+
+      return transitions[0]?.target;
+    }
+
+    const { generateAICompletion } = await import("@/app/utils/streamAI");
+    const transitionSummary = transitions.map((transition) => ({
+      target: transition.target,
+      label: transition.label,
+    }));
+
+    const response = await generateAICompletion({
+      aiConfig: hookReturn.aiConfig,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You choose the next state in an X-Reason state machine. Return only JSON shaped as {\"target\":\"<exact target>\"}.",
+        },
+        {
+          role: "user",
+          content: JSON.stringify(
+            {
+              originalQuery: query,
+              currentState: stateLabel,
+              currentResult: result,
+              availableTransitions: transitionSummary,
+              executionTrace: trace.map((entry) => ({
+                state: entry.state,
+                event: entry.event,
+                target: entry.target,
+              })),
+              context,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+
+    return matchTransitionTarget(response, transitions) || transitions[0]?.target;
+  };
+
+  const waitForHumanApproval = (state: StateConfig, stateLabel: string) => {
+    setExecutionResults(prev => [...prev, {
+      state: stateLabel,
+      result: "Waiting for human approval.",
+      timestamp: new Date(),
+    }]);
+
+    return new Promise<string>((resolve) => {
+      setPendingHumanApproval({
+        stateLabel,
+        task: state.task,
+        approve: () => {
+          const result = `HUMAN_DECISION: approved ${stateLabel}`;
+          setPendingHumanApproval(null);
+          setExecutionResults(prev => [...prev, {
+            state: stateLabel,
+            result,
+            timestamp: new Date(),
+          }]);
+          resolve(result);
+        },
+        requestChanges: () => {
+          const result = `HUMAN_DECISION: changes_requested ${stateLabel}`;
+          setPendingHumanApproval(null);
+          setExecutionResults(prev => [...prev, {
+            state: stateLabel,
+            result,
+            timestamp: new Date(),
+          }]);
+          resolve(result);
+        },
       });
+    });
   };
 
   const executeStateMachine = async () => {
@@ -290,31 +456,49 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
         await initializeInspector();
       }
 
-      // Create an actor from the compiled machine for visualization
-      if (compiledMachine.machine) {
-        const actor = createActor(compiledMachine.machine);
-        setCurrentActor(actor);
-        actor.start();
-      }
+      const result = await runStateMachineInterpreter({
+        states: compiledMachine.stateConfigs as StateConfig[],
+        query: savedInputValue,
+        executeState: async ({ state, stateLabel }) => {
+          if (stateRequiresHumanApproval(state, stateLabel)) {
+            return waitForHumanApproval(state, stateLabel);
+          }
 
-      // Execute each state sequentially
-      const states = getExecutableStates();
+          const fixtureResult =
+            savedInputValue === AGENTIC_WORKFLOW_SAMPLE_QUERY
+              ? getAgenticWorkflowSampleStateResult(stateLabel)
+              : undefined;
 
-      console.log(`Executing ${states.length} states sequentially`);
+          if (fixtureResult) {
+            setExecutionResults(prev => [...prev, {
+              state: stateLabel,
+              result: fixtureResult,
+              timestamp: new Date(),
+            }]);
+            return fixtureResult;
+          }
 
-      for (const state of states) {
-        const stateName = state.id as string;
-        console.log(`Starting execution of state: ${stateName}`);
-        setCurrentExecutionState(stateName);
-
-        try {
-          await simulateStateExecution(stateName, savedInputValue);
-          console.log(`Completed execution of state: ${stateName}`);
-        } catch (error) {
-          console.error(`Error executing state ${stateName}:`, error);
-          // Continue with next state even if this one fails
-        }
-      }
+          return simulateStateExecution(stateLabel, savedInputValue);
+        },
+        chooseTransition: chooseTransitionWithAI,
+        onCurrentState: setCurrentExecutionState,
+        onCompleteState: (stateLabel) => {
+          setCompletedStates(prev => {
+            if (prev.has(stateLabel)) return prev;
+            const newSet = new Set(prev);
+            newSet.add(stateLabel);
+            return newSet;
+          });
+        },
+        onTrace: (entry) => {
+          if (entry.event !== "transition") return;
+          setExecutionResults(prev => [...prev, {
+            state: entry.state,
+            result: `Transitioned to ${entry.target}`,
+            timestamp: entry.timestamp,
+          }]);
+        },
+      });
 
       console.log('All states executed successfully');
       setIsExecuting(false);
@@ -323,12 +507,13 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
       // Add final completion message
       setExecutionResults(prev => [...prev, {
         state: 'final-summary',
-        result: `Execution complete.\n\nAll ${states.length} steps have been executed successfully. Review the results above to verify each step completed as expected.`,
+        result: `Execution complete.\n\nVisited ${result.completedStates.length} runtime steps and reached ${result.finalState || 'a final state'}. Review the results above to verify each step completed as expected.`,
         timestamp: new Date()
       }]);
 
     } catch (error) {
       console.error('Error executing state machine:', error);
+      setPendingHumanApproval(null);
       setExecutionResults(prev => [...prev, {
         state: 'error',
         result: `Error executing state machine: ${error}`,
@@ -565,6 +750,7 @@ Describe what happens in this step concisely. Start directly with the action, no
               onSelect={fillSampleQuery}
               disabled={isLoading}
               isExpanded={hookReturn.isExpanded}
+              sampleBadges={config.sampleQueryBadges}
             />
           )}
 
@@ -766,7 +952,7 @@ Describe what happens in this step concisely. Start directly with the action, no
                 <div className="flex items-center justify-between">
                   <div>
                     <h4 className="text-sm font-semibold text-gray-800">
-                      {compiledMachine.id}
+                      {String(compiledMachine.id)}
                     </h4>
                     <p className="text-xs text-gray-600">
                       {compiledMachine.states ? Object.keys(compiledMachine.states).length : 0} states
@@ -778,14 +964,15 @@ Describe what happens in this step concisely. Start directly with the action, no
               <div className="flex-1 p-4">
                 {(() => {
                   // Convert functions map to stepsMap format for visualization
-                  const stepsMap = new Map<string, Record<string, unknown>>();
+                  const stepsMap = new Map<string, { id: string; func: unknown; type?: 'pause' | 'async' }>();
                   if (compiledMachine.functions) {
                     (compiledMachine.functions as Map<string, unknown>).forEach((func: unknown, key: string) => {
                       const stateConfig = (compiledMachine.stateConfigs as Array<Record<string, unknown>>)?.find((s: Record<string, unknown>) => s.id === key);
+                      const stateType = ((stateConfig as Record<string, unknown>)?.meta as Record<string, unknown>)?.type;
                       stepsMap.set(key, {
                         id: key,
                         func: func,
-                        type: ((stateConfig as Record<string, unknown>)?.meta as Record<string, unknown>)?.type as string || 'async'
+                        type: stateType === 'pause' ? 'pause' : 'async'
                       });
                     });
                   }
@@ -793,7 +980,6 @@ Describe what happens in this step concisely. Start directly with the action, no
                   return (
                     <StateMachineVisualizer 
                       machine={compiledMachine.machine}
-                      interpreter={currentActor}
                       stepsMap={stepsMap}
                       inline={true}
                       className="!static !w-full !bottom-auto !right-auto !transform-none !fixed-none"
@@ -910,6 +1096,36 @@ Describe what happens in this step concisely. Start directly with the action, no
             </div>
           )}
         </div>
+
+        {pendingHumanApproval && (
+          <div className="border border-amber-200 bg-amber-50 rounded-lg p-4 space-y-3">
+            <div>
+              <h4 className="text-sm font-semibold text-amber-900">
+                Human approval required: {pendingHumanApproval.stateLabel}
+              </h4>
+              {pendingHumanApproval.task && (
+                <p className="text-sm text-amber-800 mt-1">
+                  {pendingHumanApproval.task}
+                </p>
+              )}
+            </div>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <Button
+                onClick={pendingHumanApproval.requestChanges}
+                variant="outline"
+                className="border-amber-300 bg-white text-amber-900 hover:bg-amber-100"
+              >
+                Request changes
+              </Button>
+              <Button
+                onClick={pendingHumanApproval.approve}
+                className="bg-amber-700 text-white hover:bg-amber-800"
+              >
+                Approve
+              </Button>
+            </div>
+          </div>
+        )}
 
         {/* Execution Checklist */}
         <div className="border rounded-lg bg-white max-h-[500px] overflow-y-auto">

--- a/apps/x-reason-web/src/app/test/stateMachineExecution.test.ts
+++ b/apps/x-reason-web/src/app/test/stateMachineExecution.test.ts
@@ -1,0 +1,163 @@
+import { StateConfig } from "../api/reasoning";
+import { createAgenticWorkflowTortureFixture } from "../api/reasoning/fixtures/agenticWorkflow";
+import {
+  cloneStateConfigs,
+  collectExecutableStates,
+  getStateLabel,
+  matchTransitionTarget,
+  runStateMachineInterpreter,
+  selectHumanApprovalTransition,
+  stateRequiresHumanApproval,
+} from "../utils/stateMachineExecution";
+
+describe("stateMachineExecution", () => {
+  it("collects nested executable states without final or parallel container nodes", () => {
+    const executableStates = collectExecutableStates(createAgenticWorkflowTortureFixture());
+
+    expect(executableStates.map((state) => state.id)).toEqual([
+      "DraftPlan",
+      "ResearchMarket",
+      "ReviewCompliance",
+      "CritiquePlan",
+      "RevisePlan",
+      "HumanApproval",
+      "ExecutePlan",
+    ]);
+  });
+
+  it("matches exact transition targets and display labels from model output", () => {
+    const transitions = [
+      {
+        on: "CONTINUE",
+        target: "RevisePlan|11111111-1111-4111-8111-111111111111",
+        label: "RevisePlan",
+      },
+      {
+        on: "CONTINUE",
+        target: "HumanApproval|22222222-2222-4222-8222-222222222222",
+        label: "HumanApproval",
+      },
+    ];
+
+    expect(matchTransitionTarget('{"target":"HumanApproval"}', transitions)).toBe(
+      "HumanApproval|22222222-2222-4222-8222-222222222222",
+    );
+    expect(
+      matchTransitionTarget(
+        '"RevisePlan|11111111-1111-4111-8111-111111111111"',
+        transitions,
+      ),
+    ).toBe("RevisePlan|11111111-1111-4111-8111-111111111111");
+  });
+
+  it("detects and routes human approval states", () => {
+    const fixture = createAgenticWorkflowTortureFixture();
+    const humanApproval = fixture.find((state) => state.id === "HumanApproval");
+    const critiquePlan = fixture.find((state) => state.id === "CritiquePlan");
+    const transitions = [
+      { on: "CONTINUE", target: "RevisePlan", label: "RevisePlan" },
+      { on: "CONTINUE", target: "ExecutePlan", label: "ExecutePlan" },
+    ];
+
+    expect(humanApproval).toBeDefined();
+    expect(critiquePlan).toBeDefined();
+    expect(stateRequiresHumanApproval(humanApproval!)).toBe(true);
+    expect(stateRequiresHumanApproval(critiquePlan!)).toBe(false);
+    expect(selectHumanApprovalTransition("approved", transitions)).toBe("ExecutePlan");
+    expect(selectHumanApprovalTransition("changes_requested", transitions)).toBe("RevisePlan");
+  });
+
+  it("preserves source fixture ids when cloning before compilation", () => {
+    const fixture = createAgenticWorkflowTortureFixture();
+    const cloned = cloneStateConfigs(fixture);
+
+    cloned[0].id = "Mutated";
+
+    expect(fixture[0].id).toBe("DraftPlan");
+  });
+
+  it("executes a non-linear agentic workflow through the interpreter path", async () => {
+    const critiqueVisits: string[] = [];
+
+    const result = await runStateMachineInterpreter({
+      states: createAgenticWorkflowTortureFixture(),
+      query: "Create an agentic workflow with a revision loop.",
+      pollIntervalMs: 1,
+      executeState: async ({ stateLabel }) => {
+        if (stateLabel === "CritiquePlan") {
+          critiqueVisits.push(stateLabel);
+          return critiqueVisits.length === 1
+            ? "The plan needs one revision."
+            : "The revised plan is ready for human approval.";
+        }
+
+        return `${stateLabel} completed`;
+      },
+      chooseTransition: async ({ stateLabel, transitions }) => {
+        if (stateLabel !== "CritiquePlan") {
+          return transitions[0]?.target;
+        }
+
+        const targetLabel = critiqueVisits.length === 1 ? "RevisePlan" : "HumanApproval";
+        return transitions.find((transition) => getStateLabel(transition.target) === targetLabel)
+          ?.target;
+      },
+    });
+
+    expect(result.finalState).toBe("success");
+    expect(result.completedStates).toEqual([
+      "DraftPlan",
+      "ResearchMarket",
+      "ReviewCompliance",
+      "CritiquePlan",
+      "RevisePlan",
+      "CritiquePlan",
+      "HumanApproval",
+      "ExecutePlan",
+    ]);
+    expect(
+      result.trace
+        .filter((entry) => entry.event === "transition")
+        .map((entry) => [entry.state, entry.target]),
+    ).toEqual([
+      ["DraftPlan", "ParallelDiscovery"],
+      ["CritiquePlan", "RevisePlan"],
+      ["RevisePlan", "CritiquePlan"],
+      ["CritiquePlan", "HumanApproval"],
+      ["HumanApproval", "ExecutePlan"],
+      ["ExecutePlan", "success"],
+    ]);
+  });
+
+  it("stops cyclic workflows that never reach a final state", async () => {
+    const states: StateConfig[] = [
+      {
+        id: "Draft",
+        transitions: [
+          { on: "CONTINUE", target: "Review" },
+          { on: "ERROR", target: "failure" },
+        ],
+      },
+      {
+        id: "Review",
+        transitions: [
+          { on: "CONTINUE", target: "Draft" },
+          { on: "ERROR", target: "failure" },
+        ],
+      },
+      { id: "success", type: "final" },
+      { id: "failure", type: "final" },
+    ];
+
+    await expect(
+      runStateMachineInterpreter({
+        states,
+        query: "Loop forever",
+        maxTransitions: 3,
+        pollIntervalMs: 1,
+        executeState: async ({ stateLabel }) => `${stateLabel} completed`,
+        chooseTransition: async ({ transitions }) => transitions[0]?.target,
+      }),
+    ).rejects.toThrow("exceeded 3 transitions");
+  });
+});

--- a/apps/x-reason-web/src/app/utils/index.ts
+++ b/apps/x-reason-web/src/app/utils/index.ts
@@ -1,6 +1,7 @@
 export * from './storeFactory';
 export * from './aiLogger';
 export * from './stateMachineJson';
+export * from './stateMachineExecution';
 export { default as factory } from './factory';
 export { extractJsonFromBackticks } from '@codestrap/developer-foundations-utils';
 

--- a/apps/x-reason-web/src/app/utils/stateMachineExecution.ts
+++ b/apps/x-reason-web/src/app/utils/stateMachineExecution.ts
@@ -1,0 +1,399 @@
+import {
+  Context,
+  headlessInterpreter,
+  MachineEvent,
+  StateConfig,
+  Task,
+} from "@/app/api/reasoning";
+
+export type ExecutionResult = {
+  state: string;
+  result: string;
+  timestamp: Date;
+};
+
+export type ExecutionTraceEntry = {
+  state: string;
+  event: "enter" | "complete" | "transition" | "final" | "error";
+  result?: string;
+  target?: string;
+  timestamp: Date;
+};
+
+export type TransitionOption = {
+  on: string;
+  target: string;
+  label: string;
+};
+
+export type HumanApprovalDecision = "approved" | "changes_requested";
+
+export type ExecuteState = (input: {
+  state: StateConfig;
+  stateId: string;
+  stateLabel: string;
+  query: string;
+  context: Context;
+  event?: MachineEvent;
+}) => Promise<string>;
+
+export type ChooseTransition = (input: {
+  state: StateConfig;
+  stateId: string;
+  stateLabel: string;
+  query: string;
+  result: string;
+  context: Context;
+  transitions: TransitionOption[];
+  trace: ExecutionTraceEntry[];
+}) => Promise<string | undefined>;
+
+export type RunStateMachineOptions = {
+  states: StateConfig[];
+  query: string;
+  executeState: ExecuteState;
+  chooseTransition?: ChooseTransition;
+  context?: Partial<Context>;
+  maxTransitions?: number;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  onTrace?: (entry: ExecutionTraceEntry) => void;
+  onCurrentState?: (stateLabel: string) => void;
+  onCompleteState?: (stateLabel: string) => void;
+};
+
+export type RunStateMachineResult = {
+  trace: ExecutionTraceEntry[];
+  completedStates: string[];
+  context: Context;
+  finalState?: string;
+};
+
+const UUID_SUFFIX = /\|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function cloneStateConfigs(states: StateConfig[]): StateConfig[] {
+  return JSON.parse(JSON.stringify(states)) as StateConfig[];
+}
+
+export function getStateLabel(stateId: string): string {
+  return stateId.replace(UUID_SUFFIX, "");
+}
+
+export function getFunctionCatalogKey(stateId: string): string {
+  return getStateLabel(stateId).split("|")[0] || stateId;
+}
+
+export function collectExecutableStates(states: StateConfig[]): StateConfig[] {
+  const collected: StateConfig[] = [];
+  const seen = new Set<StateConfig>();
+
+  const visit = (state: StateConfig) => {
+    if (seen.has(state)) return;
+    seen.add(state);
+
+    if (state.type !== "final" && state.type !== "parallel") {
+      collected.push(state);
+    }
+
+    state.states?.forEach(visit);
+  };
+
+  states.forEach(visit);
+  return collected;
+}
+
+export function getTransitionOptions(state: StateConfig): TransitionOption[] {
+  return (state.transitions || [])
+    .filter((transition) => transition.on === "CONTINUE" && Boolean(transition.target))
+    .map((transition) => ({
+      on: transition.on,
+      target: transition.target,
+      label: getStateLabel(transition.target),
+    }));
+}
+
+export function matchTransitionTarget(
+  responseText: string,
+  transitions: TransitionOption[],
+): string | undefined {
+  const trimmed = responseText.trim();
+
+  try {
+    const parsed = JSON.parse(trimmed) as { target?: unknown };
+    if (typeof parsed.target === "string") {
+      const exact = transitions.find((transition) => transition.target === parsed.target);
+      if (exact) return exact.target;
+
+      const byLabel = transitions.find((transition) => transition.label === parsed.target);
+      if (byLabel) return byLabel.target;
+    }
+  } catch {
+    // Fall through to plain text matching.
+  }
+
+  const unquoted = trimmed.replace(/^`+|`+$/g, "").replace(/^"|"$/g, "");
+  const exact = transitions.find((transition) => transition.target === unquoted);
+  if (exact) return exact.target;
+
+  return transitions.find((transition) => transition.label === unquoted)?.target;
+}
+
+export function stateRequiresHumanApproval(state: StateConfig, stateLabel = getStateLabel(state.id)) {
+  const searchableText = `${stateLabel} ${state.task || ""}`.toLowerCase();
+
+  return (
+    searchableText.includes("humanapproval") ||
+    searchableText.includes("human approval") ||
+    searchableText.includes("manual approval") ||
+    searchableText.includes("approval before")
+  );
+}
+
+export function selectHumanApprovalTransition(
+  decision: HumanApprovalDecision,
+  transitions: TransitionOption[],
+): string | undefined {
+  if (decision === "approved") {
+    return (
+      transitions.find((transition) => {
+        const label = transition.label.toLowerCase();
+        return (
+          /(execute|success|final|approved|proceed|continue)/.test(label) &&
+          !/(revise|revision|reject|change|critique)/.test(label)
+        );
+      })?.target || transitions[0]?.target
+    );
+  }
+
+  return (
+    transitions.find((transition) =>
+      /(revise|revision|changes|edit|draft|critique|review)/.test(
+        transition.label.toLowerCase(),
+      ),
+    )?.target || transitions[0]?.target
+  );
+}
+
+function createTrace(
+  entry: Omit<ExecutionTraceEntry, "timestamp">,
+  trace: ExecutionTraceEntry[],
+  onTrace?: (entry: ExecutionTraceEntry) => void,
+) {
+  const withTimestamp = { ...entry, timestamp: new Date() };
+  trace.push(withTimestamp);
+  onTrace?.(withTimestamp);
+}
+
+function markChildStates(states: StateConfig[]) {
+  const childStates = new WeakSet<StateConfig>();
+
+  const visit = (state: StateConfig) => {
+    state.states?.forEach((child) => {
+      childStates.add(child);
+      visit(child);
+    });
+  };
+
+  states.forEach(visit);
+  return childStates;
+}
+
+function selectFallbackTransition(state: StateConfig): string {
+  return getTransitionOptions(state)[0]?.target || "success";
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function runStateMachineInterpreter({
+  states,
+  query,
+  executeState,
+  chooseTransition,
+  context,
+  maxTransitions = 60,
+  pollIntervalMs = 50,
+  timeoutMs = 10 * 60 * 1000,
+  onTrace,
+  onCurrentState,
+  onCompleteState,
+}: RunStateMachineOptions): Promise<RunStateMachineResult> {
+  const runtimeStates = cloneStateConfigs(states);
+  const childStates = markChildStates(runtimeStates);
+  const trace: ExecutionTraceEntry[] = [];
+  const completedStates: string[] = [];
+  const functions = new Map<string, Task>();
+
+  let runner:
+    | ReturnType<typeof headlessInterpreter>
+    | undefined;
+  let failure: Error | undefined;
+  let transitionCount = 0;
+  let finalState: string | undefined;
+
+  const sendTransition = (event: MachineEvent) => {
+    if (failure || runner?.done()) return;
+    runner?.send(event);
+  };
+
+  collectExecutableStates(runtimeStates).forEach((state) => {
+    const stateId = state.id;
+    const stateLabel = getStateLabel(stateId);
+    const functionKey = getFunctionCatalogKey(stateId);
+
+    functions.set(functionKey, {
+      description: state.task || stateLabel,
+      transitions:
+        getTransitionOptions(state).length > 1
+          ? new Map(
+              getTransitionOptions(state).map((transition) => [
+                `CONTINUE|${getFunctionCatalogKey(transition.target)}`,
+                () => false,
+              ]),
+            )
+          : undefined,
+      implementation: async (machineContext: Context, event?: MachineEvent) => {
+        const currentStateId = state.id;
+        const currentStateLabel = getStateLabel(currentStateId);
+        const isNestedState = childStates.has(state);
+
+        createTrace({ state: currentStateLabel, event: "enter" }, trace, onTrace);
+        onCurrentState?.(currentStateLabel);
+
+        try {
+          const result = await executeState({
+            state,
+            stateId: currentStateId,
+            stateLabel: currentStateLabel,
+            query,
+            context: machineContext,
+            event,
+          });
+
+          createTrace(
+            { state: currentStateLabel, event: "complete", result },
+            trace,
+            onTrace,
+          );
+          completedStates.push(currentStateLabel);
+          onCompleteState?.(currentStateLabel);
+
+          if (isNestedState) {
+            return { result };
+          }
+
+          const transitions = getTransitionOptions(state);
+          const selectedTarget =
+            (await chooseTransition?.({
+              state,
+              stateId: currentStateId,
+              stateLabel: currentStateLabel,
+              query,
+              result,
+              context: machineContext,
+              transitions,
+              trace,
+            })) || selectFallbackTransition(state);
+
+          createTrace(
+            {
+              state: currentStateLabel,
+              event: "transition",
+              target: getStateLabel(selectedTarget),
+            },
+            trace,
+            onTrace,
+          );
+
+          sendTransition({
+            type: selectedTarget,
+            payload: {
+              [currentStateId]: result,
+              [currentStateLabel]: result,
+            },
+          });
+        } catch (error) {
+          const executionError =
+            error instanceof Error ? error : new Error(String(error));
+          failure = executionError;
+          createTrace(
+            {
+              state: currentStateLabel,
+              event: "error",
+              result: executionError.message,
+            },
+            trace,
+            onTrace,
+          );
+          sendTransition({
+            type: "failure",
+            payload: {
+              [currentStateId]: executionError.message,
+              [currentStateLabel]: executionError.message,
+            },
+          });
+        }
+      },
+    });
+  });
+
+  const dispatch = (action: { type: string; value?: { currentState?: { value?: unknown } } }) => {
+    if (action.type !== "SET_STATE") return;
+
+    const stateValue = action.value?.currentState?.value;
+    const stateLabel = getStateLabel(String(stateValue || ""));
+    if (!stateLabel) return;
+
+    finalState = stateLabel;
+    if (stateLabel === "success" || stateLabel === "failure") {
+      createTrace({ state: stateLabel, event: "final" }, trace, onTrace);
+      onCurrentState?.("");
+      return;
+    }
+
+    transitionCount += 1;
+    if (transitionCount > maxTransitions) {
+      failure = new Error(
+        `State machine exceeded ${maxTransitions} transitions before reaching a final state.`,
+      );
+      runner?.stop();
+    }
+  };
+
+  runner = headlessInterpreter(
+    runtimeStates,
+    functions,
+    dispatch,
+    {
+      requestId: "state-machine-execution",
+      status: 0,
+      stack: [],
+      ...context,
+    } as Context,
+  );
+
+  runner.start();
+
+  const timeoutAt = Date.now() + timeoutMs;
+  while (Date.now() < timeoutAt) {
+    if (failure || runner.done()) break;
+    await delay(pollIntervalMs);
+  }
+
+  if (failure) {
+    throw failure;
+  }
+
+  if (!runner.done()) {
+    runner.stop();
+    throw new Error("State machine did not reach a final state before timing out.");
+  }
+
+  return {
+    trace,
+    completedStates,
+    context: runner.getContext(),
+    finalState,
+  };
+}


### PR DESCRIPTION
## Summary

Adds an interpreter-backed execution path for generated X-Reason state machines so the demo can run non-linear graphs instead of walking the state list sequentially. The new runner preserves generated state IDs for the XState core, strips UUID suffixes for UI display, traces runtime progress, handles nested parallel branches, supports bounded loops, and asks the selected AI provider to choose between multiple valid `CONTINUE` targets.

Also adds a deterministic agentic workflow sample covering parallel discovery, critique/revision backtracking, human approval, and final execution. The first Chemli sample now loads that fixture directly so it is a reliable end-to-end demo path, including a real UI pause with `Request changes` and `Approve` controls before execution can continue. The visualizer now renders sanitized Mermaid node IDs, transition arrays/objects, `onDone` edges, and meaningful nested child states.

## Validation

- `pnpm --filter x-reason lint`
- `pnpm --filter x-reason exec jest --runInBand`
- `pnpm build`
- `git diff --check`
- Browser smoke at `http://localhost:3000/pages/chemli`: loaded the first agentic sample, compiled the fixture graph, executed until `Human approval required: HumanApproval`, clicked `Approve`, and verified it reached `success`.

## Notes

- I also probed `pnpm --filter x-reason exec tsc --noEmit`; it still fails on existing app-wide type debt in unrelated files. The modified template errors from the first probe were cleaned up before this PR.
