### PR TITLE
fix: prevent demo layout clipping

### DIFF
--- a/apps/x-reason-web/src/app/components/ProgressBar.tsx
+++ b/apps/x-reason-web/src/app/components/ProgressBar.tsx
@@ -16,14 +16,14 @@ interface ProgressBarProps {
 
 export const ProgressBar: React.FC<ProgressBarProps> = ({ steps, currentStep, className }) => {
   return (
-    <div className={cn("w-full", className)}>
-      <div className="flex items-center justify-between">
+    <div className={cn("w-full px-2 sm:px-3", className)}>
+      <div className="flex items-start">
         {steps.map((step, index) => (
           <React.Fragment key={step.id}>
-            <div className="flex flex-col items-center">
+            <div className="flex shrink-0 flex-col items-center">
               <div
                 className={cn(
-                  "w-10 h-10 rounded-full flex items-center justify-center text-sm font-medium transition-colors",
+                  "flex h-10 w-10 items-center justify-center rounded-full text-sm font-medium transition-colors",
                   index < currentStep
                     ? "bg-primary text-primary-foreground"
                     : index === currentStep
@@ -49,12 +49,12 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({ steps, currentStep, cl
                   index + 1
                 )}
               </div>
-              <span className="mt-2 text-xs text-center max-w-[100px]">{step.label}</span>
+              <span className="mt-2 max-w-[100px] text-center text-xs">{step.label}</span>
             </div>
             {index < steps.length - 1 && (
               <div
                 className={cn(
-                  "flex-1 h-0.5 mx-2 transition-colors",
+                  "mx-2 mt-5 h-0.5 min-w-0 flex-1 transition-colors",
                   index < currentStep ? "bg-primary" : "bg-muted"
                 )}
               />

--- a/apps/x-reason-web/src/app/templates/AgentDemoTemplate.tsx
+++ b/apps/x-reason-web/src/app/templates/AgentDemoTemplate.tsx
@@ -122,7 +122,7 @@ export const SampleQueries = ({ samples, onSelect, disabled, isExpanded, sampleB
                 <p className="text-xs text-muted-foreground mb-3">
                     Sample Requests (click to use):
                 </p>
-                <div className="flex flex-wrap gap-1 mb-3 overflow-hidden">
+                <div className="-m-0.5 mb-2 flex flex-wrap gap-1 overflow-visible p-0.5">
                     {samples.map((sample, index) => {
                         const isLong = sample.length > truncationLength;
                         const displayText = isLong ? `${sample.substring(0, truncationLength)}...` : sample;
@@ -135,19 +135,19 @@ export const SampleQueries = ({ samples, onSelect, disabled, isExpanded, sampleB
                                 size="sm"
                                 onClick={() => onSelect(sample)}
                                 disabled={disabled}
-                                className={`text-xs min-h-7 h-auto px-2 py-1 max-w-[calc(100%-0.25rem)] flex-shrink min-w-0 break-words ${
+                                className={`h-auto min-h-7 max-w-full min-w-0 shrink px-2 py-1 text-xs whitespace-normal ${
                                     badge
                                         ? 'border-amber-300 bg-amber-50 text-amber-950 hover:bg-amber-100'
                                         : ''
                                 }`}
                             >
-                                <span className="flex min-w-0 items-center gap-1.5">
+                                <span className="flex min-w-0 max-w-full items-center gap-1.5">
                                     {badge && (
                                         <span className="shrink-0 rounded border border-amber-300 bg-white px-1 py-0.5 text-[10px] font-semibold uppercase leading-none text-amber-800">
                                             {badge}
                                         </span>
                                     )}
-                                    <span className="truncate block w-full text-left">{displayText}</span>
+                                    <span className="block min-w-0 truncate text-left">{displayText}</span>
                                 </span>
                             </Button>
                         );

--- a/apps/x-reason-web/src/app/templates/MultiStepAgentDemoTemplate.tsx
+++ b/apps/x-reason-web/src/app/templates/MultiStepAgentDemoTemplate.tsx
@@ -10,7 +10,7 @@ import { StateMachineVisualizer } from "@/app/components/StateMachineVisualizer"
 import { AgentDemoTemplateProps, ResponsiveContainer, SampleQueries, JsonHighlighter } from "./AgentDemoTemplate";
 import { Textarea } from "@/app/components/ui/textarea";
 import { AIProviderSelector } from "@/app/components/ui/ai-provider-selector";
-import { ArrowUp, ArrowLeft, ArrowRight, Play, Copy, Check, ChevronDown, ChevronRight } from 'lucide-react';
+import { ArrowUp, ArrowLeft, ArrowRight, Play, Copy, Check, ChevronDown, ChevronRight, FileText } from 'lucide-react';
 import Interpreter from "@/app/api/reasoning/Interpreter.v1.headed";
 import { LocalStorage } from "@/app/components";
 import { programV1, StateConfig, Task } from '@/app/api/reasoning';
@@ -1173,8 +1173,8 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
         )}
 
         {/* Execution Checklist */}
-        <div className="border rounded-lg bg-white max-h-[500px] overflow-y-auto">
-          <div className="p-4">
+        <div className="overflow-hidden rounded-lg border border-slate-200 bg-white">
+          <div className="max-h-[500px] overflow-y-auto p-4 [scrollbar-gutter:stable]">
             <h4 className="text-sm font-semibold mb-4 flex items-center">
               <div className="h-2 w-2 bg-green-500 rounded-full mr-2"></div>
               Execution Progress
@@ -1198,11 +1198,11 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
                   const canToggleResults = hasResults && (isCompleted || isCurrent);
                   
                   return (
-                    <div key={`${state.id}-${index}`} className="border rounded-lg">
+                    <div key={`${state.id}-${index}`} className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
                       <div 
-                        className={`flex items-center justify-between p-3 cursor-pointer ${
+                        className={`flex cursor-pointer items-center justify-between gap-3 p-3 ${
                           displayStatus === 'current' ? 'bg-blue-50' :
-                          displayStatus === 'completed' ? 'bg-green-50' : 'bg-gray-50'
+                          displayStatus === 'completed' ? 'bg-green-50' : 'bg-slate-50'
                         }`}
                         onClick={() => {
                           if (canToggleResults) {
@@ -1218,8 +1218,8 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
                           }
                         }}
                       >
-                        <div className="flex items-center space-x-3">
-                          <div className={`w-5 h-5 rounded-full flex items-center justify-center ${
+                        <div className="flex min-w-0 items-center gap-3">
+                          <div className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full ${
                             displayStatus === 'current' ? 'bg-blue-500 text-white' :
                             displayStatus === 'completed' ? 'bg-green-500 text-white' :
                             'bg-gray-300 text-gray-600'
@@ -1232,8 +1232,8 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
                               <span className="text-xs">{index + 1}</span>
                             )}
                           </div>
-                          <div>
-                            <div className="text-sm font-medium text-gray-800">{state.id as string}</div>
+                          <div className="min-w-0">
+                            <div className="truncate text-sm font-medium text-gray-800">{state.id as string}</div>
                             <div className="text-xs text-gray-500">
                               {displayStatus === 'current'
                                 ? 'In Progress'
@@ -1253,7 +1253,7 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
 
                       {/* Expandable content - show when not collapsed */}
                       {hasResults && !isCollapsed && (
-                        <div className="border-t bg-white">
+                        <div className="border-t border-slate-200 bg-white">
                           <div className="p-3 space-y-2">
                             {executionResults
                               .filter(result => result.state === state.id as string)
@@ -1301,17 +1301,17 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
           </div>
         </div>
 
-        <div className="flex flex-col sm:flex-row justify-between gap-2">
-          <Button onClick={handleBack} variant="outline" size="lg" className="w-full sm:w-auto">
+        <div className="grid gap-2 lg:grid-cols-[max-content_minmax(0,1fr)] lg:items-center">
+          <Button onClick={handleBack} variant="outline" size="lg" className="w-full min-w-0 px-4 sm:px-6 lg:w-auto">
             <ArrowLeft className="mr-2 h-4 w-4" />
             Back to Visualization
           </Button>
-          <div className="flex flex-col sm:flex-row gap-2">
+          <div className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-3 lg:flex lg:flex-wrap lg:justify-end">
             {!isExecuting && (
               <Button
                 onClick={executeStateMachine}
                 size="lg"
-                className={`w-full sm:w-auto ${hasExecutedBefore ? "bg-gray-500 hover:bg-gray-600" : "bg-green-600 hover:bg-green-700"}`}
+                className={`w-full min-w-0 px-4 sm:px-6 lg:w-auto ${hasExecutedBefore ? "bg-gray-500 hover:bg-gray-600" : "bg-green-600 hover:bg-green-700"}`}
               >
                 <Play className="mr-2 h-4 w-4" />
                 {hasExecutedBefore ? 'Re-execute' : 'Execute'}
@@ -1322,11 +1322,12 @@ export function MultiStepAgentDemoTemplate({ config, hookReturn, inputRef }: Age
               variant="outline"
               size="lg"
               disabled={!executionResults.length || isExecuting}
-              className={`w-full sm:w-auto ${!executionResults.length || isExecuting ? "opacity-50 cursor-not-allowed" : ""}`}
+              className={`w-full min-w-0 px-4 sm:px-6 lg:w-auto ${!executionResults.length || isExecuting ? "opacity-50 cursor-not-allowed" : ""}`}
             >
-              📄 Download Report
+              <FileText className="mr-2 h-4 w-4" />
+              Download Report
             </Button>
-            <Button onClick={() => setCurrentStep(0)} variant="outline" size="lg" className="w-full sm:w-auto">
+            <Button onClick={() => setCurrentStep(0)} variant="outline" size="lg" className="w-full min-w-0 px-4 sm:px-6 lg:w-auto">
               Start New Task
             </Button>
           </div>


### PR DESCRIPTION
## Summary

- Gives the shared stepper enough horizontal space for active ring styling so edge circles do not clip at narrow widths.
- Lets sample-query chips on Chemli and Regie own their shrink/truncation instead of being clipped by an overflow-hidden wrapper.
- Separates execution checklist borders from the scroll viewport and makes the execution action row wrap/grid cleanly across breakpoints.

## Root Cause

Several demo surfaces mixed clipping, scroll, and flex wrapping responsibilities in the same container. At select viewport widths, borders, focus rings, and long button labels were forced against parent edges, which made rounded corners look chopped or let action buttons exceed their available space.

## Validation

- `pnpm --filter x-reason lint`
- `pnpm --filter x-reason build`
- `git diff --check`
- Browser checked `/pages/chemli` and `/pages/regie` at 390, 461, 640, 768, 1024, and 1270 px widths for sample-chip overflow/clipping.